### PR TITLE
docs: add MMELON to pretrained models list

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ A meticulously curated resource list focused on computational methods for drug d
 - [MolBERT](https://github.com/BenevolentAI/MolBERT) - Transformer-based molecular representation learning.
 - [ChemBERTa](https://huggingface.co/seyonec/ChemBERTa-zinc-base-v1) - Pretrained BERT-like models for molecules from SMILES.
 - [Uni-Mol](https://github.com/dptech-corp/Uni-Mol) - 3D molecular representation learning framework.
-- [Boltz-2](https://github.com/jwohlwend/boltz) - A foundation model that jointly predicts structure and binding affinity, rivaling physics-based FEP methods in accuracy.  
+- [Boltz-2](https://github.com/jwohlwend/boltz) - A foundation model that jointly predicts structure and binding affinity, rivaling physics-based FEP methods in accuracy.
+- [MMELON](https://github.com/BiomedSciAI/biomed-multi-view) - Multi-view Molecular Embedding with Late Fusion combining graph, image, and text representations.
 
 ### AutoML and Optimization
 - [Auto-sklearn](https://automl.github.io/auto-sklearn/master/) - Automated machine learning for scikit-learn.


### PR DESCRIPTION
Added MMELON to the Pretrained Models section under Machine Learning and AI in the README.

---
*PR created automatically by Jules for task [8932782062859717739](https://jules.google.com/task/8932782062859717739) started by @yboulaamane*