### PR TITLE
Add morfeus to descriptor tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ A meticulously curated resource list focused on computational methods for drug d
 - [CDK](https://cdk.github.io/) - Java cheminformatics library with descriptor calculators.  
 - [alvaDesc](https://www.alvascience.com/alvadesc/) - Commercial software for molecular descriptors and fingerprints.  
 - [MolFeat](https://molfeat.datamol.io/) - Python package for molecular featurization and embeddings.
+- [Morfeus](https://github.com/digital-chemistry-laboratory/morfeus) - Python package for calculating 3D steric and electronic parameters of molecules.
 - [Dragon](https://www.talete.mi.it/products/dragon_description.htm) - Commercial molecular descriptor calculator (widely cited).
 - [ChemDescriptor](https://github.com/darkreactions/chemdescriptor) - Open-source tool for generating chemical descriptors and fingerprints, supporting cheminformatics workflows.
 


### PR DESCRIPTION
### Summary of Changes
Added `morfeus` to the **Descriptor and Featurization Tools** section.

### Description
- **Project:** [morfeus](https://github.com/digital-chemistry-laboratory/morfeus)
- **Reason for addition:** `morfeus` is a widely-used Python package designed for calculating 3D steric and electronic parameters (e.g., Sterimol, buried volume, partial charges) of molecules, making it a valuable resource for 3D molecular featurization in drug discovery workflows.
- Followed the contribution guidelines (concise description ending with a period).